### PR TITLE
Updated build process to correctly scope the main file in bower.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,12 +45,6 @@ module.exports = function(grunt) {
         files: [
           {
             expand: true,
-            src: ['./bower.json'],
-            dest: 'dist/',
-            filter: 'isFile'
-          }, //copy bower.json
-          {
-            expand: true,
             src: ['./*.md'],
             dest: 'dist/',
             filter: 'isFile'
@@ -65,9 +59,21 @@ module.exports = function(grunt) {
     'jshint',
     'concat',
     'uglify',
-    'copy'
+    'copy',
+    'bowerdist'
   ]);
 
   grunt.registerTask('default', [ 'build' ]);
   grunt.registerTask('watchme', [ 'watch' ]);
+
+  grunt.registerTask('bowerdist', function () {
+    var bower = require('./bower.json');
+    var fs = require('fs');
+
+    bower.main = bower.main.map(function (main) {
+      return main.replace('dist/', '');
+    });
+
+    fs.writeFileSync('./dist/bower.json', JSON.stringify(bower, null, 2));
+  });
 };

--- a/dist/bower.json
+++ b/dist/bower.json
@@ -2,7 +2,9 @@
   "name": "angular-gestures",
   "description": "AngularJS directive that adds support for multi touch gestures to your app. Based on hammer.js.",
   "version": "0.3.0",
-  "main": ["dist/gestures.min.js"],
+  "main": [
+    "gestures.min.js"
+  ],
   "homepage": "http://github.com/wzr1337/angular-gestures",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The problem is that the `dist` folder becomes https://github.com/wzr1337/bower-angular-gestures and the `main` property points to an invalid location. If someone something like https://www.npmjs.org/package/main-bower-files, this package won't resolve correctly which defeats the purpose of bower.

This pull request addresses that issue by processing the `bower.json` file instead of just copying it. This way if someone does a `bower install wzr1337/angular-gestures` (this repository) their stuff will work correctly. If someone does `bower install angular-gestures`, (official way) that will also work correctly.
