### PR TITLE
Add note to readme regarding hammer.js requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ AngularJS directive that adds support for multi touch gestures to your app, base
 * You can use angular interpolations like this : `hm-swipe="remove_something({{ id }})"`
 * You can also use Hammer.js options by e.g. `hm-tap-opts="{hold: false}"`
 
+Note that [hammer.js](http://hammerjs.github.io/) is an additional requirement and is not included in `angular-gestures`.
+
 ### Event data
 
 Pass the `$event` object in the usual way e.g. `hm-drag="myDrag($event)"` then access its internals like so:


### PR DESCRIPTION
I spent 15+ minutes trying to debug my app before realising that hammer.js was not included in angular-gesture. This may seem obvious to some but there is no mention of this requirement in the Usage instructions.
This PR adds a little note to remind those like me that `hammer.js` is also a requirement.